### PR TITLE
Allowed to save profiler log to file

### DIFF
--- a/keras_flops/flops_calculation.py
+++ b/keras_flops/flops_calculation.py
@@ -9,7 +9,10 @@ from tensorflow.keras import Sequential, Model
 import keras_flops.flops_registory
 
 
-def get_flops(model: Union[Model, Sequential], batch_size: Optional[int] = None) -> int:
+def get_flops(model: Union[Model, Sequential], \
+              batch_size: Optional[int] = None,\
+              order_by = 'name',\
+              outfile = None) -> int:
     """
     Calculate FLOPS for tf.keras.Model or tf.keras.Sequential .
     Ignore operations used in only training mode such as Initialization.
@@ -34,6 +37,9 @@ def get_flops(model: Union[Model, Sequential], batch_size: Optional[int] = None)
     # Calculate FLOPS with tf.profiler
     run_meta = tf.compat.v1.RunMetadata()
     opts = tf.compat.v1.profiler.ProfileOptionBuilder.float_operation()
+    opts['order_by'] = order_by
+    if outfile != None:
+        opts['output'] = f'file:outfile={outfile}'
     flops = tf.compat.v1.profiler.profile(
         graph=frozen_func.graph, run_meta=run_meta, cmd="scope", options=opts
     )

--- a/keras_flops/flops_calculation.py
+++ b/keras_flops/flops_calculation.py
@@ -36,12 +36,16 @@ def get_flops(model: Union[Model, Sequential], \
 
     # Calculate FLOPS with tf.profiler
     run_meta = tf.compat.v1.RunMetadata()
-    opts = tf.compat.v1.profiler.ProfileOptionBuilder.float_operation()
-    opts['order_by'] = order_by
+    opts = tf.compat.v1.profiler.ProfileOptionBuilder(
+               tf.compat.v1.profiler.ProfileOptionBuilder.float_operation())
+    opts.order_by(order_by)
     if outfile != None:
-        opts['output'] = f'file:outfile={outfile}'
+        opts.with_file_output(outfile)
+    else:
+        opts.with_stdout_output()
+
     flops = tf.compat.v1.profiler.profile(
-        graph=frozen_func.graph, run_meta=run_meta, cmd="scope", options=opts
+        graph=frozen_func.graph, run_meta=run_meta, cmd="scope", options=opts.build()
     )
     # print(frozen_func.graph.get_operations())
     # TODO: show each FLOPS


### PR DESCRIPTION
Added extra parameters to the get_flops() function so to change tf.profiler options in order to change result order and/or save the log to some specified file

This is necessary since the redirect_stdout of the contextlib module does not work on the output of the tf.profile log