### PR TITLE
Update get_flops() to accept kwargs and pass them to tf.compat.v1.profiler.ProfileOptionBuilder.float_operation()

### DIFF
--- a/keras_flops/flops_calculation.py
+++ b/keras_flops/flops_calculation.py
@@ -9,7 +9,7 @@ from tensorflow.keras import Sequential, Model
 import keras_flops.flops_registory
 
 
-def get_flops(model: Union[Model, Sequential], batch_size: Optional[int] = None) -> int:
+def get_flops(model: Union[Model, Sequential], batch_size: Optional[int] = None, **kwargs) -> int:
     """
     Calculate FLOPS for tf.keras.Model or tf.keras.Sequential .
     Ignore operations used in only training mode such as Initialization.
@@ -34,6 +34,7 @@ def get_flops(model: Union[Model, Sequential], batch_size: Optional[int] = None)
     # Calculate FLOPS with tf.profiler
     run_meta = tf.compat.v1.RunMetadata()
     opts = tf.compat.v1.profiler.ProfileOptionBuilder.float_operation()
+    opts.update(kwargs)
     flops = tf.compat.v1.profiler.profile(
         graph=frozen_func.graph, run_meta=run_meta, cmd="scope", options=opts
     )


### PR DESCRIPTION
Very useful, thank you. 
Added this small change on my machine.
--------------------------
This PR updates the get_flops() function to accept kwargs and pass them to the tf.compat.v1.profiler.ProfileOptionBuilder.float_operation() function. This allows users to pass additional options to the tf.profiler.profile() function, which can be useful for debugging or performance analysis.

Example: 
flops = get_flops(model, batch_size=1, order_by='flops')
